### PR TITLE
Fix outdated e2e tests

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -7,8 +7,8 @@ describe('cv App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
+  it('should display the main title', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('Welcome to app!');
+    expect(page.getMainTitleText()).toEqual('Mauricio Beltrán');
   });
 });

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -5,7 +5,7 @@ export class AppPage {
     return browser.get('/');
   }
 
-  getParagraphText() {
-    return element(by.css('app-root h1')).getText();
+  getMainTitleText() {
+    return element(by.css('app-root .title')).getText();
   }
 }


### PR DESCRIPTION
## Summary
- update e2e page object to read the title div
- check for the current title in e2e spec

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: The test command requires to be run in an Angular project, but a project definition could not be found.)*
- `npm run lint` *(fails: The lint command requires to be run in an Angular project, but a project definition could not be found.)*

------
https://chatgpt.com/codex/tasks/task_e_684032118d348324a97c6542f4776491